### PR TITLE
feat(NA): Make buffer size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ General configuration for a Statful client.
     * sampleRate [optional] [default: 100] [between: 1-100] - global rate sampling
     * namespace [optional] [default: ‘application’] - default namespace (can be overridden in method calls)
     * flushSize [optional] [default: 10] - defines the periodicity of buffer flushes
-    * flushInterval [optional] [default: 0] - Defines an interval to flush the metrics
+    * flushInterval [optional] [default: 0] - defines an interval to flush the metrics
+    * maxBufferSize [optional] [default: 5000] - defines how many metrics at max are kept in memory between flushes
 
 Vertx Statful specific configurations:
 

--- a/src/main/java/com/statful/client/StatfulMetricsOptions.java
+++ b/src/main/java/com/statful/client/StatfulMetricsOptions.java
@@ -104,6 +104,11 @@ public class StatfulMetricsOptions extends MetricsOptions {
     private static final boolean DEFAULT_METRIC_COLLECTION = true;
 
     /**
+     * Default maximum theoretical buffer size that holds metrics in memory between flushes
+     */
+    private static final int DEFAULT_MAX_BUFFER_SIZE = 5000;
+
+    /**
      * Statful host, default value {@value #DEFAULT_HOST}
      */
     private Optional<String> host = Optional.empty();
@@ -230,6 +235,10 @@ public class StatfulMetricsOptions extends MetricsOptions {
     private boolean enableHttpServerMetrics = DEFAULT_METRIC_COLLECTION;
 
     /**
+     * Maximum theoretical buffer size that holds metrics in memory between flushes
+     */
+    private int maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;
+    /**
      * Empty constructor that provides default values, all of which should be overridable
      */
     public StatfulMetricsOptions() {
@@ -265,6 +274,7 @@ public class StatfulMetricsOptions extends MetricsOptions {
         this.enablePoolMetrics = other.enablePoolMetrics;
         this.enableHttpClientMetrics = other.enableHttpClientMetrics;
         this.enableHttpServerMetrics = other.enableHttpServerMetrics;
+        this.maxBufferSize = other.maxBufferSize;
     }
 
 
@@ -315,10 +325,12 @@ public class StatfulMetricsOptions extends MetricsOptions {
 
         this.gaugeReportingInterval = config.getLong("gauge-reporting-interval", DEFAULT_GAUGE_REPORTING_INTERVAL);
 
-        JsonObject collectors = config.getJsonObject("collectors");
+        JsonObject collectors = config.getJsonObject("collectors", new JsonObject(Collections.emptyMap()));
         this.enablePoolMetrics = collectors.getBoolean("pool", DEFAULT_METRIC_COLLECTION);
         this.enableHttpClientMetrics = collectors.getBoolean("httpClient", DEFAULT_METRIC_COLLECTION);
         this.enableHttpServerMetrics = collectors.getBoolean("httpServer", DEFAULT_METRIC_COLLECTION);
+
+        this.maxBufferSize = config.getInteger("maxBufferSize", DEFAULT_MAX_BUFFER_SIZE);
     }
 
     private List<Aggregation> parseAggregationsConfiguration(final String key, final JsonObject config, final List<Aggregation> defaultConfig) {
@@ -795,6 +807,23 @@ public class StatfulMetricsOptions extends MetricsOptions {
      */
     public StatfulMetricsOptions setEnableHttpServerMetrics(final boolean enableHttpServerMetrics) {
         this.enableHttpServerMetrics = enableHttpServerMetrics;
+        return this;
+    }
+
+    /**
+     * @return gets the max number of metrics to be kept in memory
+     */
+    public int getMaxBufferSize() {
+        return this.maxBufferSize;
+    }
+
+    /**
+     * Sets the max number of metrics to be kept in memory
+     * @param maxBufferSize value to set
+     * @return a reference to this, so the API can be used fluently
+     */
+    public StatfulMetricsOptions setMaxBufferSize(final int maxBufferSize) {
+        this.maxBufferSize = maxBufferSize;
         return this;
     }
 }

--- a/src/main/java/com/statful/sender/MetricsHolder.java
+++ b/src/main/java/com/statful/sender/MetricsHolder.java
@@ -19,10 +19,6 @@ import java.util.stream.Collectors;
 abstract class MetricsHolder implements Sender {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetricsHolder.class);
-    /**
-     * Maximum theoretical buffer size to old on to metrics before sending them
-     */
-    private static final int MAX_BUFFER_SIZE = 5000;
 
     /**
      * Buffer to hold metrics
@@ -51,7 +47,7 @@ abstract class MetricsHolder implements Sender {
 
         this.sampler = Objects.requireNonNull(sampler);
 
-        this.buffer = new ArrayBlockingQueue<>(MAX_BUFFER_SIZE);
+        this.buffer = new ArrayBlockingQueue<>(options.getMaxBufferSize());
     }
 
     /**

--- a/src/test/java/com/statful/client/StatfulMetricsOptionsTest.java
+++ b/src/test/java/com/statful/client/StatfulMetricsOptionsTest.java
@@ -211,6 +211,18 @@ public class StatfulMetricsOptionsTest {
         assertFalse(victim.setEnableHttpServerMetrics(false).isEnableHttpServerMetrics());
     }
 
+    @Test
+    public void testDefaultBiggerThenZeroBufferSize() {
+        assertTrue(victim.getMaxBufferSize() > 0);
+    }
+
+    @Test
+    public void testSetMaxBufferSize() {
+        int newSize = victim.getMaxBufferSize() + 1;
+        victim.setMaxBufferSize(newSize);
+        assertEquals(newSize, victim.getMaxBufferSize());
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void testCopyCtor() {

--- a/src/test/java/com/statful/client/VertxMetricsImplTest.java
+++ b/src/test/java/com/statful/client/VertxMetricsImplTest.java
@@ -29,6 +29,7 @@ public class VertxMetricsImplTest {
         when(this.vertx.getOrCreateContext()).thenReturn(this.context);
         this.statfulMetricsOptions = mock(StatfulMetricsOptions.class);
         when(statfulMetricsOptions.getTransport()).thenReturn(Transport.UDP);
+        when(statfulMetricsOptions.getMaxBufferSize()).thenReturn(5000);
     }
 
 

--- a/src/test/java/com/statful/sender/MetricsHolderTest.java
+++ b/src/test/java/com/statful/sender/MetricsHolderTest.java
@@ -20,6 +20,7 @@ public class MetricsHolderTest {
 
         StatfulMetricsOptions options = mock(StatfulMetricsOptions.class);
         when(options.isDryrun()).thenReturn(false);
+        when(options.getMaxBufferSize()).thenReturn(5000);
 
         Sampling sampling = mock(Sampling.class);
         when(sampling.shouldInsert()).thenReturn(false);
@@ -33,6 +34,7 @@ public class MetricsHolderTest {
 
         StatfulMetricsOptions options = mock(StatfulMetricsOptions.class);
         when(options.isDryrun()).thenReturn(false);
+        when(options.getMaxBufferSize()).thenReturn(5000);
 
         Sampling sampling = mock(Sampling.class);
         when(sampling.shouldInsert()).thenReturn(true);
@@ -44,7 +46,7 @@ public class MetricsHolderTest {
     private static final class DummyMetricsHolder extends MetricsHolder {
 
 
-        public DummyMetricsHolder(StatfulMetricsOptions options, Sampling sampler) {
+        DummyMetricsHolder(StatfulMetricsOptions options, Sampling sampler) {
             super(options, sampler);
         }
 


### PR DESCRIPTION
Metrics are kept in memory for batch sending. Prior to this change the maximum number of metrics in memory was hard coded, it's now configurable on StatfulMetricsOptions.

Fixed some code warnings, unrelated with this change