### PR TITLE
fix(#4): Flush buffer immediately when flush size is reached

### DIFF
--- a/src/main/java/com/statful/sender/HttpSender.java
+++ b/src/main/java/com/statful/sender/HttpSender.java
@@ -58,7 +58,7 @@ public class HttpSender extends MetricsHolder {
                     .setSsl(options.isSecure());
 
             this.client = vertx.createHttpClient(httpClientOptions);
-            this.configureFlushInterval(vertx, this.options.getFlushInterval(), this.options.getFlushSize());
+            this.configureFlushInterval(vertx, this.options.getFlushInterval());
         });
     }
 

--- a/src/main/java/com/statful/sender/MetricsHolder.java
+++ b/src/main/java/com/statful/sender/MetricsHolder.java
@@ -72,7 +72,7 @@ abstract class MetricsHolder implements Sender {
 
         boolean inserted = this.buffer.offer(dataPoint);
 
-        this.shouldFlush(inserted);
+        this.flushOnCapacity(inserted);
 
         if (!inserted) {
             LOGGER.warn("metric could not be added to buffer, discarding it {} ", dataPoint.toMetricLine());
@@ -84,10 +84,8 @@ abstract class MetricsHolder implements Sender {
      * If a metric could not be added to the buffer tries to flush the buffer.
      * Also check if a the buffer has at least as many items as the flush size and tries to flush the buffer
      */
-    private void shouldFlush(final boolean inserted) {
-        if (!inserted) {
-            this.flush();
-        } else if (this.buffer.size() >= flushSize) {
+    private void flushOnCapacity(final boolean inserted) {
+        if (!inserted || this.buffer.size() >= flushSize) {
             this.flush();
         }
     }

--- a/src/main/java/com/statful/sender/MetricsHolder.java
+++ b/src/main/java/com/statful/sender/MetricsHolder.java
@@ -32,12 +32,17 @@ abstract class MetricsHolder implements Sender {
     private final boolean dryrun;
 
     /**
+     * Number of elements to remove from the buffer
+     */
+    private final int flushSize;
+
+    /**
      * Sampler to be used to decide if a metric should be added or not
      */
     private Sampling sampler;
 
     /**
-     * Initializes the internal buffer. Implementers must call {@link #configureFlushInterval(Vertx, long, int)} to init
+     * Initializes the internal buffer. Implementers must call {@link #configureFlushInterval(Vertx, long)} to init
      * the process of sending metrics
      *
      * @param options Statful configuration to decide if metrics should be sent or not
@@ -49,6 +54,8 @@ abstract class MetricsHolder implements Sender {
         this.sampler = Objects.requireNonNull(sampler);
 
         this.buffer = new ArrayBlockingQueue<>(options.getMaxBufferSize());
+
+        this.flushSize = options.getFlushSize();
     }
 
     /**
@@ -64,6 +71,9 @@ abstract class MetricsHolder implements Sender {
         }
 
         boolean inserted = this.buffer.offer(dataPoint);
+
+        this.shouldFlush(inserted);
+
         if (!inserted) {
             LOGGER.warn("metric could not be added to buffer, discarding it {} ", dataPoint.toMetricLine());
         }
@@ -71,19 +81,34 @@ abstract class MetricsHolder implements Sender {
     }
 
     /**
+     * If a metric could not be added to the buffer tries to flush the buffer.
+     * Also check if a the buffer has at least as many items as the flush size and tries to flush the buffer
+     */
+    private void shouldFlush(final boolean inserted) {
+        if (!inserted) {
+            this.flush();
+            return;
+        }
+
+        int size = this.buffer.size();
+        if (size >= flushSize) {
+            this.flush();
+        }
+    }
+
+    /**
      * Methods uses vertx instance to set a periodic interval
      *
      * @param vertx         instance to create the periodic interval on
      * @param flushInterval time between flushes
-     * @param flushSize     number of elements to clean from the buffer
      */
-    void configureFlushInterval(final Vertx vertx, final long flushInterval, final int flushSize) {
-        vertx.setPeriodic(flushInterval, timerId -> flush(flushSize));
+    void configureFlushInterval(final Vertx vertx, final long flushInterval) {
+        vertx.setPeriodic(flushInterval, timerId -> flush());
     }
 
-    private void flush(final int flushSize) {
-        List<DataPoint> toBeSent = Lists.newArrayListWithCapacity(flushSize);
-        buffer.drainTo(toBeSent, flushSize);
+    private void flush() {
+        List<DataPoint> toBeSent = Lists.newArrayListWithCapacity(this.flushSize);
+        buffer.drainTo(toBeSent, this.flushSize);
 
         if (dryrun) {
             final String toSendMetrics = toBeSent.stream().map(DataPoint::toMetricLine).collect(Collectors.joining("\n"));

--- a/src/main/java/com/statful/sender/MetricsHolder.java
+++ b/src/main/java/com/statful/sender/MetricsHolder.java
@@ -87,11 +87,7 @@ abstract class MetricsHolder implements Sender {
     private void shouldFlush(final boolean inserted) {
         if (!inserted) {
             this.flush();
-            return;
-        }
-
-        int size = this.buffer.size();
-        if (size >= flushSize) {
+        } else if (this.buffer.size() >= flushSize) {
             this.flush();
         }
     }

--- a/src/main/java/com/statful/sender/UDPSender.java
+++ b/src/main/java/com/statful/sender/UDPSender.java
@@ -47,7 +47,7 @@ public final class UDPSender extends MetricsHolder {
         // so that we can open a socket and configure a interval
         context.runOnContext(aVoid -> {
             this.socket = vertx.createDatagramSocket(new DatagramSocketOptions());
-            this.configureFlushInterval(vertx, this.options.getFlushInterval(), this.options.getFlushSize());
+            this.configureFlushInterval(vertx, this.options.getFlushInterval());
         });
     }
 

--- a/src/test/java/com/statful/sender/MetricsHolderTest.java
+++ b/src/test/java/com/statful/sender/MetricsHolderTest.java
@@ -8,7 +8,9 @@ import org.junit.Test;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
@@ -43,7 +45,30 @@ public class MetricsHolderTest {
         assertTrue(dummy.addMetric(mock(DataPoint.class)));
     }
 
+    @Test
+    public void testFlushIfBufferFull() {
+
+        StatfulMetricsOptions options = mock(StatfulMetricsOptions.class);
+        when(options.isDryrun()).thenReturn(false);
+        when(options.getMaxBufferSize()).thenReturn(5);
+        when(options.getFlushSize()).thenReturn(5);
+
+        Sampling sampling = mock(Sampling.class);
+        when(sampling.shouldInsert()).thenReturn(true);
+
+        DummyMetricsHolder dummy = new DummyMetricsHolder(options, sampling);
+        assertTrue(dummy.addMetric(mock(DataPoint.class)));
+        assertTrue(dummy.addMetric(mock(DataPoint.class)));
+        assertTrue(dummy.addMetric(mock(DataPoint.class)));
+        assertTrue(dummy.addMetric(mock(DataPoint.class)));
+        assertTrue(dummy.addMetric(mock(DataPoint.class)));
+        assertTrue(dummy.addMetric(mock(DataPoint.class)));
+        assertEquals(1, dummy.adder.intValue());
+    }
+
     private static final class DummyMetricsHolder extends MetricsHolder {
+
+        private LongAdder adder = new LongAdder();
 
 
         DummyMetricsHolder(StatfulMetricsOptions options, Sampling sampler) {
@@ -52,12 +77,12 @@ public class MetricsHolderTest {
 
         @Override
         public void send(@Nonnull List<DataPoint> metrics, @Nonnull Handler<AsyncResult<Void>> sentHandler) {
-
+            adder.increment();
         }
 
         @Override
         public void send(@Nonnull List<DataPoint> metrics) {
-
+            adder.increment();
         }
 
         @Override


### PR DESCRIPTION
Also tries to flush if a metric fails to be added to the buffer