### PR TITLE
fix(#19) - Remove prefix as a valid configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ The configuration file is a simple json document, a sample can be seen bellow
 
 General configuration for a Statful client.
 
-    * prefix [required] - global metrics prefix
     * host [optional] [default: '127.0.0.1']
     * port [optional] [default: 2013]
     * secure [not supported yet] [default: true] - enable or disable https

--- a/src/main/java/com/statful/client/CustomMetric.java
+++ b/src/main/java/com/statful/client/CustomMetric.java
@@ -90,7 +90,6 @@ public class CustomMetric implements DataPoint {
     @Override
     public String toMetricLine() {
         final MetricLineBuilder metricLineBuilder = new MetricLineBuilder()
-                .withPrefix(this.options.getPrefix())
                 .withNamespace(this.options.getNamespace())
                 .withMetricType(metricType)
                 .withMetricName(this.metricName)

--- a/src/main/java/com/statful/client/StatfulMetricsOptions.java
+++ b/src/main/java/com/statful/client/StatfulMetricsOptions.java
@@ -124,11 +124,6 @@ public class StatfulMetricsOptions extends MetricsOptions {
     private Optional<Integer> port = Optional.empty();
 
     /**
-     * Prefix to be added to all metrics.
-     */
-    private String prefix;
-
-    /**
      * Defines the transport to be used to set which type of transport will be used to push the metrics.
      */
     private Transport transport = DEFAULT_TRANSPORT;
@@ -265,7 +260,6 @@ public class StatfulMetricsOptions extends MetricsOptions {
 
         this.host = other.host;
         this.port = other.port;
-        this.prefix = other.prefix;
         this.transport = other.transport;
         this.secure = other.secure;
         this.timeout = other.timeout;
@@ -300,7 +294,6 @@ public class StatfulMetricsOptions extends MetricsOptions {
 
         this.host = Optional.of(config.getString("host", DEFAULT_HOST));
         this.port = Optional.of(config.getInteger("port", DEFAULT_PORT));
-        this.prefix = config.getString("prefix");
         this.transport = Transport.valueOf(config.getString("transport", DEFAULT_TRANSPORT.toString()));
         this.secure = Optional.of(config.getBoolean("secure", DEFAULT_SECURE));
         this.timeout = Optional.of(config.getInteger("timeout", DEFAULT_TIMEOUT));
@@ -396,27 +389,6 @@ public class StatfulMetricsOptions extends MetricsOptions {
     @Nonnull
     public Integer getPort() {
         return port.orElse(DEFAULT_PORT);
-    }
-
-    /**
-     * @param prefix to be applied
-     * @return a reference to this, so the API can be used fluently
-     */
-    public StatfulMetricsOptions setPrefix(@Nonnull final String prefix) {
-        this.prefix = requireNonNull(prefix);
-        return this;
-    }
-
-    /**
-     * Get defined prefix
-     *
-     * @return String with the prefix
-     * @throws NullPointerException if prefix is undefined
-     */
-    @Nonnull
-    public String getPrefix() {
-        requireNonNull(prefix, "Prefix must be set");
-        return prefix;
     }
 
     /**

--- a/src/main/java/com/statful/metric/HttpDataPoint.java
+++ b/src/main/java/com/statful/metric/HttpDataPoint.java
@@ -102,7 +102,6 @@ public abstract class HttpDataPoint implements DataPoint {
     protected MetricLineBuilder buildMetricLine() {
 
         final MetricLineBuilder metricLineBuilder = new MetricLineBuilder()
-                .withPrefix(this.options.getPrefix())
                 .withNamespace(this.options.getNamespace())
                 .withMetricType(MetricType.TIMER)
                 .withMetricName(this.metricName)

--- a/src/main/java/com/statful/metric/MetricLineBuilder.java
+++ b/src/main/java/com/statful/metric/MetricLineBuilder.java
@@ -21,10 +21,6 @@ public final class MetricLineBuilder {
     private String app;
 
     /**
-     * Prefix to be set in the metric
-     */
-    private String prefix;
-    /**
      * Namespace to be set in the metric
      */
     private String namespace;
@@ -77,15 +73,13 @@ public final class MetricLineBuilder {
     public String build() {
         final StringBuilder sb = new StringBuilder();
 
-        sb.append(this.prefix);
-
         if (!Strings.isNullOrEmpty(this.namespace)) {
-            sb.append(".").append(this.namespace);
+            sb.append(this.namespace).append(".");
         }
 
-        sb.append(".").append(metricType.toString());
+        sb.append(metricType.toString()).append(".");
 
-        sb.append(".").append(metricName);
+        sb.append(metricName);
 
         // merge application to the tag list
         getApp().ifPresent(application -> this.tags.put("app", application));
@@ -135,17 +129,6 @@ public final class MetricLineBuilder {
      */
     public MetricLineBuilder withApp(final String application) {
         this.app = application;
-        return this;
-    }
-
-    /**
-     * @param prefixToAdd to be added to the metric
-     * @return a reference to this, so the API can be used fluently
-     */
-    @Nonnull
-    public MetricLineBuilder withPrefix(@Nonnull final String prefixToAdd) {
-        Objects.requireNonNull(prefixToAdd);
-        this.prefix = prefixToAdd;
         return this;
     }
 

--- a/src/main/java/com/statful/metric/PoolDataPoint.java
+++ b/src/main/java/com/statful/metric/PoolDataPoint.java
@@ -56,7 +56,6 @@ public class PoolDataPoint implements DataPoint {
     @Override
     public String toMetricLine() {
         final MetricLineBuilder metricLineBuilder = new MetricLineBuilder()
-                .withPrefix(this.options.getPrefix())
                 .withNamespace(this.options.getNamespace())
                 .withMetricType(MetricType.GAUGE)
                 .withMetricName("pool")

--- a/src/test/java/com/statful/client/StatfulHttpClientIntegrationTest.java
+++ b/src/test/java/com/statful/client/StatfulHttpClientIntegrationTest.java
@@ -44,7 +44,6 @@ public class StatfulHttpClientIntegrationTest extends IntegrationTestCase {
                 .setTransport(Transport.HTTP)
                 .setFlushInterval(1000)
                 .setFlushSize(20)
-                .setPrefix("testing")
                 .setSecure(false)
                 .setToken("a token")
                 .setEnabled(true)

--- a/src/test/java/com/statful/client/StatfulMetricsOptionsTest.java
+++ b/src/test/java/com/statful/client/StatfulMetricsOptionsTest.java
@@ -47,24 +47,6 @@ public class StatfulMetricsOptionsTest {
 
     @SuppressWarnings("all")
     @Test(expected = NullPointerException.class)
-    public void testSetNullPrefix() {
-        victim.setPrefix(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testMandatorySetPrefix() {
-        victim.getPrefix();
-    }
-
-    @Test
-    public void testSetPrefix() {
-        victim.setPrefix("prefix");
-        assertEquals("prefix", victim.getPrefix());
-    }
-
-
-    @SuppressWarnings("all")
-    @Test(expected = NullPointerException.class)
     public void testSetNullTransport() {
         victim.setTransport(null);
     }
@@ -227,7 +209,7 @@ public class StatfulMetricsOptionsTest {
     @Test
     public void testCopyCtor() {
         victim.setApp("app").setDryrun(true).setFlushSize(10).setHost("host").setNamespace("namespace")
-                .setPort(9999).setPrefix("prefix").setSampleRate(10).setSecure(true)
+                .setPort(9999).setSampleRate(10).setSecure(true)
                 .setTimeout(1000).setToken("token").setTransport(Transport.UDP).setEnabled(true)
                 .setTags(Lists.newArrayList(new Pair<>("tag", "value")));
 
@@ -237,7 +219,6 @@ public class StatfulMetricsOptionsTest {
         assertEquals(victim.getFlushSize(), copy.getFlushSize());
         assertEquals(victim.getNamespace(), copy.getNamespace());
         assertEquals(victim.getPort(), copy.getPort());
-        assertEquals(victim.getPrefix(), copy.getPrefix());
         assertEquals(victim.getSampleRate(), copy.getSampleRate());
         assertEquals(victim.isSecure(), copy.isSecure());
         assertTrue(victim.getTags().containsAll(copy.getTags()));
@@ -253,7 +234,6 @@ public class StatfulMetricsOptionsTest {
         JsonObject configuration = new JsonObject()
                 .put("host", "host")
                 .put("port", 1111)
-                .put("prefix", "prefix")
                 .put("transport", Transport.HTTP.toString())
                 .put("secure", false)
                 .put("timeout", 100)
@@ -273,7 +253,6 @@ public class StatfulMetricsOptionsTest {
         victim = new StatfulMetricsOptions(configuration);
         assertEquals(victim.getHost(), "host");
         assertEquals(victim.getPort(), new Integer(1111));
-        assertEquals(victim.getPrefix(), "prefix");
         assertEquals(victim.getTransport(), Transport.HTTP);
         assertFalse(victim.isSecure());
         assertEquals(victim.getTimeout(), 100);

--- a/src/test/java/com/statful/client/StatfulUDPClientIntegrationTest.java
+++ b/src/test/java/com/statful/client/StatfulUDPClientIntegrationTest.java
@@ -45,7 +45,6 @@ public class StatfulUDPClientIntegrationTest extends IntegrationTestCase {
                 .setTransport(Transport.UDP)
                 .setFlushInterval(1000)
                 .setFlushSize(20)
-                .setPrefix("testing")
                 .setEnabled(true)
                 .setEnablePoolMetrics(false)
                 .setTags(Lists.newArrayList(new Pair<>("global", "value"), new Pair<>("global1", "value1")))

--- a/src/test/java/com/statful/metric/HttpClientDataPointTest.java
+++ b/src/test/java/com/statful/metric/HttpClientDataPointTest.java
@@ -22,7 +22,6 @@ public class HttpClientDataPointTest {
     @Before
     public void setup() {
         this.options = mock(StatfulMetricsOptions.class);
-        when(this.options.getPrefix()).thenReturn("prefix");
         when(this.options.getNamespace()).thenReturn("namespace");
         when(this.options.getTimerAggregations()).thenReturn(Lists.newArrayList(Aggregation.P95));
         when(this.options.getTimerFrequency()).thenReturn(AggregationFreq.FREQ_10);
@@ -36,7 +35,7 @@ public class HttpClientDataPointTest {
         HttpClientDataPoint victim = new HttpClientDataPoint(this.options,"execution", "name", "verb", 1000, 200, HttpClientDataPoint.Type.CLIENT);
         
         // using a regex for match since the metric will include a timestamp that we don't really want to test here
-        final String expected = "prefix\\.namespace\\.timer\\.execution,request=name,verb=verb,transport=http,type=client,statusCode=200 1000 \\d.* p95,10 100";
+        final String expected = "namespace\\.timer\\.execution,request=name,verb=verb,transport=http,type=client,statusCode=200 1000 \\d.* p95,10 100";
         final String actual = victim.toMetricLine();
         
         Matcher matcher = Pattern.compile(expected).matcher(victim.toMetricLine());

--- a/src/test/java/com/statful/metric/MetricLineBuilderTest.java
+++ b/src/test/java/com/statful/metric/MetricLineBuilderTest.java
@@ -17,7 +17,6 @@ public class MetricLineBuilderTest {
     @Before
     public void setup() {
         victim = new MetricLineBuilder();
-        victim.withPrefix("prefix");
         victim.withNamespace("namespace");
         victim.withMetricType(MetricType.TIMER);
         victim.withMetricName("execution");
@@ -30,7 +29,7 @@ public class MetricLineBuilderTest {
     @Test
     public void testBuildWithoutAggregations() {
         String result = victim.build();
-        String expected = "prefix.namespace.timer.execution,tagName=tagValue value 1 100";
+        String expected = "namespace.timer.execution,tagName=tagValue value 1 100";
         assertEquals(expected, result);
     }
 
@@ -38,7 +37,6 @@ public class MetricLineBuilderTest {
     public void testBuildWithoutAggregationsWithoutTags() {
 
         victim = new MetricLineBuilder();
-        victim.withPrefix("prefix");
         victim.withNamespace("namespace");
         victim.withMetricType(MetricType.TIMER);
         victim.withMetricName("execution");
@@ -47,7 +45,7 @@ public class MetricLineBuilderTest {
         victim.withSampleRate(100);
 
         String result = victim.build();
-        String expected = "prefix.namespace.timer.execution value 1 100";
+        String expected = "namespace.timer.execution value 1 100";
         assertEquals(expected, result);
     }
 
@@ -57,7 +55,7 @@ public class MetricLineBuilderTest {
         victim.withAggregationFrequency(AggregationFreq.FREQ_120);
 
         String result = victim.build();
-        String expected = "prefix.namespace.timer.execution,tagName=tagValue value 1 100";
+        String expected = "namespace.timer.execution,tagName=tagValue value 1 100";
         assertEquals(expected, result);
     }
 
@@ -68,7 +66,7 @@ public class MetricLineBuilderTest {
         victim.withAggregationFrequency(AggregationFreq.FREQ_120);
 
         String result = victim.build();
-        String expected = "prefix.namespace.timer.execution,tagName=tagValue value 1 avg,120 100";
+        String expected = "namespace.timer.execution,tagName=tagValue value 1 avg,120 100";
         assertEquals(expected, result);
     }
 
@@ -77,7 +75,7 @@ public class MetricLineBuilderTest {
         victim.withApp("test_app");
 
         String result = victim.build();
-        String expected = "prefix.namespace.timer.execution,app=test_app,tagName=tagValue value 1 100";
+        String expected = "namespace.timer.execution,app=test_app,tagName=tagValue value 1 100";
         assertEquals(expected, result);
     }
 
@@ -86,7 +84,7 @@ public class MetricLineBuilderTest {
         victim.withSampleRate(50);
 
         String result = victim.build();
-        String expected = "prefix.namespace.timer.execution,tagName=tagValue value 1 50";
+        String expected = "namespace.timer.execution,tagName=tagValue value 1 50";
         assertEquals(expected, result);
     }
 }

--- a/src/test/resources/config/statful-wrong.json
+++ b/src/test/resources/config/statful-wrong.json
@@ -1,7 +1,6 @@
 {
   "host": "host",
   "port": 1111,
-  "prefix": "prefix",
   "transport": "UDP",
   "secure": false,
   "app": "application",

--- a/src/test/resources/config/statful.json
+++ b/src/test/resources/config/statful.json
@@ -1,7 +1,6 @@
 {
   "host": "host",
   "port": 1111,
-  "prefix": "prefix",
   "transport": "UDP",
   "secure": false,
   "app": "application",


### PR DESCRIPTION
Prefix is no longer used as an identification mechanism and it is obsolete by the existence of the namespace configuration which already prefixes a metric name.