### PR TITLE
fix(#25) - Fix the logic of handling optional and/or default aggregations

### DIFF
--- a/src/main/java/com/statful/client/CustomMetric.java
+++ b/src/main/java/com/statful/client/CustomMetric.java
@@ -127,35 +127,17 @@ public class CustomMetric implements DataPoint {
     private List<Aggregation> supplyGlobalAggregations() {
         if (!getMetricType().isPresent()) {
             return Collections.emptyList();
-        } else {
-            switch (getMetricType().get()) {
-                case GAUGE:
-                    return this.options.getGaugeAggregations();
-                case COUNTER:
-                    return this.options.getCounterAggregations();
-                case TIMER:
-                    return this.options.getTimerAggregations();
-                default:
-                    throw new IllegalArgumentException("Invalid metric type provided.");
-            }
         }
+
+        return getMetricType().get().getDefaultAggregationFromOptions(this.options);
     }
 
     private AggregationFreq supplyGlobalAggregationFrequency() {
         if (!getMetricType().isPresent()) {
             return StatfulMetricsOptions.getDefaultFrequency();
-        } else {
-            switch (getMetricType().get()) {
-                case GAUGE:
-                    return this.options.getGaugeFrequency();
-                case COUNTER:
-                    return this.options.getCounterFrequency();
-                case TIMER:
-                    return this.options.getTimerFrequency();
-                default:
-                    throw new IllegalArgumentException("Invalid metric type provided.");
-            }
         }
+
+        return getMetricType().get().getDefaultAggregationFrequencyFromOptions(this.options);
     }
 
     private StatfulMetricsOptions getOptions() {

--- a/src/main/java/com/statful/client/MetricType.java
+++ b/src/main/java/com/statful/client/MetricType.java
@@ -1,5 +1,7 @@
 package com.statful.client;
 
+import java.util.List;
+
 /**
  * Supported metric types
  */
@@ -24,6 +26,44 @@ public enum MetricType {
 
     MetricType(final String value) {
         this.value = value;
+    }
+
+    /**
+     * Returns the default aggregation list for this metric type.
+     *
+     * @param statfulMetricsOptions Configured statful client metric options
+     * @return List of {@link Aggregation}
+     */
+    public List<Aggregation> getDefaultAggregationFromOptions(final StatfulMetricsOptions statfulMetricsOptions) {
+        switch (this) {
+            case GAUGE:
+                return statfulMetricsOptions.getGaugeAggregations();
+            case COUNTER:
+                return statfulMetricsOptions.getCounterAggregations();
+            case TIMER:
+                return statfulMetricsOptions.getTimerAggregations();
+            default:
+                throw new IllegalArgumentException("Invalid metric type.");
+        }
+    }
+
+    /**
+     * Returns the default aggregation frequency for this metric type.
+     *
+     * @param statfulMetricsOptions Configured statful client metric options
+     * @return An {@link AggregationFreq}
+     */
+    public AggregationFreq getDefaultAggregationFrequencyFromOptions(final StatfulMetricsOptions statfulMetricsOptions) {
+        switch (this) {
+            case GAUGE:
+                return statfulMetricsOptions.getGaugeFrequency();
+            case COUNTER:
+                return statfulMetricsOptions.getCounterFrequency();
+            case TIMER:
+                return statfulMetricsOptions.getTimerFrequency();
+            default:
+                throw new IllegalArgumentException("Invalid metric type.");
+        }
     }
 
     @Override

--- a/src/main/java/com/statful/client/StatfulMetricsOptions.java
+++ b/src/main/java/com/statful/client/StatfulMetricsOptions.java
@@ -89,6 +89,11 @@ public class StatfulMetricsOptions extends MetricsOptions {
     private static final List<Aggregation> DEFAULT_GAUGE_AGGREGATIONS = Lists.newArrayList(Aggregation.LAST, Aggregation.MAX, Aggregation.AVG);
 
     /**
+     * Default aggregations to be applied for Counter metrics
+     */
+    private static final List<Aggregation> DEFAULT_COUNTER_AGGREGATIONS = Lists.newArrayList(Aggregation.COUNT, Aggregation.SUM);
+
+    /**
      * Default value for Aggregations Frequency for metrics
      */
     private static final AggregationFreq DEFAULT_FREQUENCY = AggregationFreq.FREQ_10;
@@ -177,6 +182,16 @@ public class StatfulMetricsOptions extends MetricsOptions {
      * Frequency of aggregation to be applied on Gauge metrics
      */
     private AggregationFreq gaugeFrequency = DEFAULT_FREQUENCY;
+
+    /**
+     * List of aggregations to be applied on Counter metrics
+     */
+    private List<Aggregation> counterAggregations = DEFAULT_COUNTER_AGGREGATIONS;
+
+    /**
+     * Frequency of aggregation to be applied on Counter metrics
+     */
+    private AggregationFreq counterFrequency = DEFAULT_FREQUENCY;
 
     /**
      * Global rate sampling. Valid range [1-100], default value {@link #DEFAULT_SAMPLE_RATE}
@@ -314,10 +329,11 @@ public class StatfulMetricsOptions extends MetricsOptions {
 
         this.timerAggregations = this.parseAggregationsConfiguration("timerAggregations", config, DEFAULT_TIMER_AGGREGATIONS);
         this.gaugeAggregations = this.parseAggregationsConfiguration("gaugeAggregations", config, DEFAULT_GAUGE_AGGREGATIONS);
+        this.counterAggregations = this.parseAggregationsConfiguration("counterAggregations", config, DEFAULT_COUNTER_AGGREGATIONS);
 
         this.timerFrequency = AggregationFreq.valueOf(config.getString("timerFrequency", DEFAULT_FREQUENCY.toString()));
-
         this.gaugeFrequency = AggregationFreq.valueOf(config.getString("gaugeFrequency", DEFAULT_FREQUENCY.toString()));
+        this.counterFrequency = AggregationFreq.valueOf(config.getString("counterFrequency", DEFAULT_FREQUENCY.toString()));
 
         this.patterns = config.getJsonArray("http-server-url-patterns", new JsonArray(Collections.emptyList())).stream()
                 .map(JsonObject.class::cast)
@@ -342,10 +358,17 @@ public class StatfulMetricsOptions extends MetricsOptions {
     private List<Aggregation> parseAggregationsConfiguration(final String key, final JsonObject config, final List<Aggregation> defaultConfig) {
         JsonArray aggregations = config.getJsonArray(key, new JsonArray(Collections.emptyList()));
 
-        if (aggregations == null || aggregations.isEmpty()) {
+        // If not aggregations config specified return the default config
+        if (aggregations == null) {
             return defaultConfig;
         }
 
+        // If aggregations config is set to an empty array return and empty aggregations list
+        if (aggregations.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // If aggregations config is set to a non-empty array return a list of aggregations values
         return aggregations
                 .stream()
                 .map(String.class::cast)
@@ -660,6 +683,50 @@ public class StatfulMetricsOptions extends MetricsOptions {
     public StatfulMetricsOptions setGaugeFrequency(@Nonnull final AggregationFreq gaugeFrequency) {
         this.gaugeFrequency = Objects.requireNonNull(gaugeFrequency);
         return this;
+    }
+
+    /**
+     * @return a copy of the aggregations applied on counter metrics
+     */
+    @Nonnull
+    public List<Aggregation> getCounterAggregations() {
+        return Lists.newArrayList(counterAggregations);
+    }
+
+    /**
+     * @param counterAggregations list of aggregations to apply
+     * @return a reference to this, so the API can be used fluently
+     */
+    @Nonnull
+    public StatfulMetricsOptions setCounterAggregations(@Nonnull final List<Aggregation> counterAggregations) {
+        this.counterAggregations = Lists.newArrayList(Objects.requireNonNull(counterAggregations));
+        return this;
+    }
+
+    /**
+     * @return the frequency to be applied on counter metrics
+     */
+    @Nonnull
+    public AggregationFreq getCounterFrequency() {
+        return counterFrequency;
+    }
+
+    /**
+     * @param counterFrequency the frequency to apply on the aggregations
+     * @return a reference to this, so the API can be used fluently
+     */
+    @Nonnull
+    public StatfulMetricsOptions setCounterFrequency(@Nonnull final AggregationFreq counterFrequency) {
+        this.counterFrequency = Objects.requireNonNull(counterFrequency);
+        return this;
+    }
+
+    /**
+     * @return the default frequency to be applied on metrics
+     */
+    @Nonnull
+    public static AggregationFreq getDefaultFrequency() {
+        return DEFAULT_FREQUENCY;
     }
 
     /**

--- a/src/main/java/com/statful/metric/MetricLineBuilder.java
+++ b/src/main/java/com/statful/metric/MetricLineBuilder.java
@@ -6,9 +6,10 @@ import com.statful.client.AggregationFreq;
 import com.statful.client.MetricType;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static java.util.Objects.isNull;
 
 /**
  * Statful metric line builder. Builds metrics lines according to Statful specification
@@ -74,18 +75,25 @@ public final class MetricLineBuilder {
     public String build() {
         final StringBuilder sb = new StringBuilder();
 
-        if (!Strings.isNullOrEmpty(this.namespace)) {
-            sb.append(this.namespace).append(".");
+        if (!Strings.isNullOrEmpty(namespace)) {
+            sb.append(namespace).append(".");
         }
 
-        if (!Objects.isNull(this.metricType)) {
+        if (!isNull(metricType)) {
             sb.append(metricType.toString()).append(".");
         }
 
         sb.append(metricName);
 
         // merge application to the tag list
-        getApp().ifPresent(application -> this.tags.putIfAbsent("app", application));
+        getApp().ifPresent(application -> {
+            if (isNull(tags)) {
+                tags = new HashMap<>();
+                tags.put("app", application);
+            }
+
+            tags.putIfAbsent("app", application);
+        });
 
         toStringTags().ifPresent(stringTag -> sb.append(",").append(stringTag));
 
@@ -130,8 +138,9 @@ public final class MetricLineBuilder {
      * @param application application name to be added to
      * @return a reference to this, so the API can be used fluently
      */
-    public MetricLineBuilder withApp(final String application) {
-        this.app = application;
+    @Nonnull
+    public MetricLineBuilder withApp(@Nonnull final String application) {
+        this.app = Objects.requireNonNull(application);
         return this;
     }
 
@@ -141,8 +150,7 @@ public final class MetricLineBuilder {
      */
     @Nonnull
     public MetricLineBuilder withNamespace(@Nonnull final String namespaceToAdd) {
-        Objects.requireNonNull(namespaceToAdd);
-        this.namespace = namespaceToAdd;
+        this.namespace = Objects.requireNonNull(namespaceToAdd);
         return this;
     }
 
@@ -152,8 +160,7 @@ public final class MetricLineBuilder {
      */
     @Nonnull
     public MetricLineBuilder withMetricName(@Nonnull final String metricNameToAdd) {
-        Objects.requireNonNull(metricNameToAdd);
-        this.metricName = metricNameToAdd;
+        this.metricName = Objects.requireNonNull(metricNameToAdd);
         return this;
     }
 
@@ -164,8 +171,7 @@ public final class MetricLineBuilder {
      */
     @Nonnull
     public MetricLineBuilder withMetricType(@Nonnull final MetricType metricTypeToAdd) {
-        Objects.requireNonNull(metricTypeToAdd);
-        this.metricType = metricTypeToAdd;
+        this.metricType = Objects.requireNonNull(metricTypeToAdd);
         return this;
     }
 
@@ -190,9 +196,9 @@ public final class MetricLineBuilder {
      * @param valueToAdd to be added to the metric
      * @return a reference to this, so the API can be used fluently
      */
+    @Nonnull
     public MetricLineBuilder withValue(@Nonnull final String valueToAdd) {
-        Objects.requireNonNull(valueToAdd);
-        this.value = valueToAdd;
+        this.value = Objects.requireNonNull(valueToAdd);
         return this;
     }
 
@@ -200,6 +206,7 @@ public final class MetricLineBuilder {
      * @param timestampToAdd to be added to the metric
      * @return a reference to this, so the API can be used fluently
      */
+    @Nonnull
     public MetricLineBuilder withTimestamp(final long timestampToAdd) {
         this.timestamp = timestampToAdd;
         return this;
@@ -209,10 +216,9 @@ public final class MetricLineBuilder {
      * @param aggregationsToAdd to be added to the metric
      * @return a reference to this, so the API can be used fluently
      */
-    public MetricLineBuilder withAggregations(@Nullable final List<Aggregation> aggregationsToAdd) {
-        if (aggregationsToAdd != null) {
-            this.aggregations.addAll(aggregationsToAdd);
-        }
+    @Nonnull
+    public MetricLineBuilder withAggregations(@Nonnull final List<Aggregation> aggregationsToAdd) {
+        this.aggregations.addAll(Objects.requireNonNull(aggregationsToAdd));
         return this;
     }
 
@@ -220,9 +226,9 @@ public final class MetricLineBuilder {
      * @param frequencyToAdd to be added to the metric
      * @return a reference to this, so the API can be used fluently
      */
+    @Nonnull
     public MetricLineBuilder withAggregationFrequency(@Nonnull final AggregationFreq frequencyToAdd) {
-        Objects.requireNonNull(frequencyToAdd);
-        this.frequency = frequencyToAdd;
+        this.frequency = Objects.requireNonNull(frequencyToAdd);
         return this;
     }
 
@@ -230,6 +236,7 @@ public final class MetricLineBuilder {
      * @param sampleRateToAdd to be added to the metric
      * @return a reference to this, so the API can be used fluently
      */
+    @Nonnull
     public MetricLineBuilder withSampleRate(final int sampleRateToAdd) {
         this.sampleRate = sampleRateToAdd;
         return this;

--- a/src/test/java/com/statful/client/StatfulCustomMetricIntegrationTest.java
+++ b/src/test/java/com/statful/client/StatfulCustomMetricIntegrationTest.java
@@ -1,0 +1,397 @@
+package com.statful.client;
+
+import com.google.common.collect.Lists;
+import com.statful.utils.Pair;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.nonNull;
+
+@RunWith(VertxUnitRunner.class)
+public class StatfulCustomMetricIntegrationTest extends IntegrationTestCase {
+
+    private static final String HOST = "0.0.0.0";
+    private static final int HTTP_SENDER_PORT = 1236;
+    private HttpServer httpMetricsReceiver;
+    private Vertx vertx;
+
+    /**
+     * Not using junit @after annotation since we want to wait for the servers to close
+     *
+     * @param async used to finish the test
+     */
+    private void teardown(Async async, TestContext context, Throwable throwable) {
+        this.teardownHttpReceiver(aVoid -> httpMetricsReceiver.close(anVoid -> {
+            if (nonNull(throwable)) {
+                context.fail(throwable);
+            } else {
+                async.complete();
+            }
+        }));
+    }
+
+    @Test
+    public void testCustomMetric(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customMetricName"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithNamespace(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+        options.setNamespace("customNamespace");
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customNamespace"));
+            context.assertTrue(metric.contains("customMetricName"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithGlobalAppTag(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+        options.setApp("customApp");
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customMetricName"));
+            context.assertTrue(metric.contains("app=customApp"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithCustomTagsAndGlobalTags(TestContext context) throws Exception {
+        List<Pair<String, String>> globalTags = new ArrayList<>(1);
+        globalTags.add(new Pair<>("globalTagName", "globalTagValue"));
+
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+        options.setTags(globalTags);
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customMetricName"));
+            context.assertTrue(metric.contains("globalTagName=globalTagValue"));
+            context.assertTrue(metric.contains("tagName=tagValue"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        Pair<String, String> tag = new Pair<>("tagName", "tagValue");
+        List<Pair<String, String>> tags = Lists.newArrayList();
+        tags.add(tag);
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withTags(tags)
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithCustomTags(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customMetricName"));
+            context.assertFalse(metric.contains("globalTagName=globalTagValue"));
+            context.assertTrue(metric.contains("tagName=tagValue"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        Pair<String, String> tag = new Pair<>("tagName", "tagValue");
+        List<Pair<String, String>> tags = Lists.newArrayList();
+        tags.add(tag);
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withTags(tags)
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithGlobalTags(TestContext context) throws Exception {
+        List<Pair<String, String>> globalTags = new ArrayList<>(1);
+        globalTags.add(new Pair<>("globalTagName", "globalTagValue"));
+
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+        options.setTags(globalTags);
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customMetricName"));
+            context.assertTrue(metric.contains("globalTagName=globalTagValue"));
+            context.assertFalse(metric.contains("tagName=tagValue"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithGlobalDefaultTimerAggregations(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customMetricName"));
+            context.assertTrue(metric.contains("avg,p90,count,10"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withMetricType(MetricType.TIMER)
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithoutAnyAggregations(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+        options.setTimerAggregations(Collections.emptyList());
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customMetricName"));
+            context.assertFalse(metric.contains("avg,p90,count,10"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withMetricType(MetricType.TIMER)
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithoutCustomAggregationsAndDefaultFrequency(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customMetricName"));
+            context.assertTrue(metric.contains("max,10"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withMetricType(MetricType.TIMER)
+                .withAggregations(Lists.newArrayList(Aggregation.MAX))
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithCustomAggregationsAndCustomFrequency(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customMetricName"));
+            context.assertTrue(metric.contains("max,120"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withMetricType(MetricType.TIMER)
+                .withAggregations(Lists.newArrayList(Aggregation.MAX))
+                .withFrequency(AggregationFreq.FREQ_120)
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithDefaultTimerAggregationsAndCustomFrequency(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+
+        setUpVertxTestContext(options);
+
+        Async async = context.async();
+
+        this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
+            String metric = body.toString();
+            context.assertTrue(metric.contains("customMetricName"));
+            context.assertTrue(metric.contains("avg,p90,count,120"));
+            teardown(async, context, null);
+        })).listen(HTTP_SENDER_PORT, HOST, event -> {
+            if (event.failed()) {
+                teardown(async, context, event.cause());
+            }
+        });
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withMetricType(MetricType.TIMER)
+                .withFrequency(AggregationFreq.FREQ_120)
+                .withValue(1L)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    private StatfulMetricsOptions getCommonStatfulMetricsOptions() {
+        StatfulMetricsOptions options = new StatfulMetricsOptions();
+        options.setPort(HTTP_SENDER_PORT)
+                .setHost(HOST)
+                .setTransport(Transport.HTTP)
+                .setFlushInterval(1000)
+                .setFlushSize(20)
+                .setSecure(false)
+                .setToken("a token")
+                .setEnabled(true)
+                .setEnablePoolMetrics(false)
+                .setEnableHttpClientMetrics(false)
+                .setEnableHttpServerMetrics(false);
+        return options;
+    }
+
+    private void setUpVertxTestContext(StatfulMetricsOptions options) throws Exception {
+        VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(options);
+
+        this.vertx = Objects.requireNonNull(Vertx.vertx(vertxOptions));
+        this.httpMetricsReceiver = this.vertx.createHttpServer();
+
+        this.setUpHttpReceiver(vertx);
+    }
+}

--- a/src/test/java/com/statful/client/StatfulHttpClientIntegrationTest.java
+++ b/src/test/java/com/statful/client/StatfulHttpClientIntegrationTest.java
@@ -92,40 +92,6 @@ public class StatfulHttpClientIntegrationTest extends IntegrationTestCase {
         testTimerMetric(metricsDisabled, context, "type=server", Optional.of("/should/ignore/"));
     }
 
-    @Test
-    public void testCustomMetric(TestContext context) {
-        Async async = context.async();
-
-        this.httpMetricsReceiver.requestHandler(packet -> {
-            packet.bodyHandler(body -> {
-                String metric = body.toString();
-                context.assertTrue(metric.contains("customMetricName"));
-                context.assertTrue(metric.contains("value1"));
-                context.assertTrue(metric.contains("tagName=tagValue"));
-                teardown(async, context, null);
-            });
-        }).listen(HTTP_SENDER_PORT, HOST, event -> {
-            if (event.failed()) {
-                teardown(async, context, event.cause());
-            }
-        });
-
-        Pair<String, String> tag = new Pair<>("tagName", "tagValue");
-        List<Pair<String, String>> tags = Lists.newArrayList();
-        tags.add(tag);
-
-        CustomMetric metric = new CustomMetric.Builder()
-                .withMetricName("customMetricName")
-                .withAggregations(Lists.newArrayList(Aggregation.AVG))
-                .withFrequency(AggregationFreq.FREQ_10)
-                .withMetricType(MetricType.TIMER)
-                .withTags(tags)
-                .withValue(1L)
-                .build();
-
-        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
-    }
-
     private void testTimerMetric(Vertx vertx, TestContext context, String tagMatcher, Optional<String> toIgnore) {
         Async async = context.async();
 

--- a/src/test/java/com/statful/client/StatfulMetricsOptionsTest.java
+++ b/src/test/java/com/statful/client/StatfulMetricsOptionsTest.java
@@ -205,6 +205,90 @@ public class StatfulMetricsOptionsTest {
         assertEquals(newSize, victim.getMaxBufferSize());
     }
 
+    @Test
+    public void testDefaultTimerAggregations() {
+        List<Aggregation> expected = Lists.newArrayList(Aggregation.AVG, Aggregation.P90, Aggregation.COUNT);
+
+        assertEquals(3, victim.getTimerAggregations().size());
+        assertTrue(victim.getTimerAggregations().containsAll(expected));
+    }
+
+    @Test
+    public void testSetTimerAggregations() {
+        victim.setTimerAggregations(Lists.newArrayList(Aggregation.LAST));
+
+        assertEquals(1, victim.getTimerAggregations().size());
+        assertTrue(victim.getTimerAggregations().contains(Aggregation.LAST));
+    }
+
+    @Test
+    public void testDefaultGaugeAggregations() {
+        List<Aggregation> expected = Lists.newArrayList(Aggregation.LAST, Aggregation.MAX, Aggregation.AVG);
+
+        assertEquals(3, victim.getGaugeAggregations().size());
+        assertTrue(victim.getGaugeAggregations().containsAll(expected));
+    }
+
+    @Test
+    public void testSetGaugeAggregations() {
+        victim.setGaugeAggregations(Lists.newArrayList(Aggregation.LAST));
+
+        assertEquals(1, victim.getGaugeAggregations().size());
+        assertTrue(victim.getGaugeAggregations().contains(Aggregation.LAST));
+    }
+
+    @Test
+    public void testDefaultCounterAggregations() {
+        List<Aggregation> expected = Lists.newArrayList(Aggregation.COUNT, Aggregation.SUM);
+
+        assertEquals(2, victim.getCounterAggregations().size());
+        assertTrue(victim.getCounterAggregations().containsAll(expected));
+    }
+
+    @Test
+    public void testSetCounterAggregations() {
+        victim.setCounterAggregations(Lists.newArrayList(Aggregation.LAST));
+
+        assertEquals(1, victim.getCounterAggregations().size());
+        assertTrue(victim.getCounterAggregations().contains(Aggregation.LAST));
+    }
+    
+    @Test
+    public void testDefaultTimerAggregationFrequency() {
+        assertEquals(AggregationFreq.FREQ_10, victim.getTimerFrequency());
+    }
+    
+    @Test
+    public void testSetTimerAggregationFrequency() {
+        victim.setTimerFrequency(AggregationFreq.FREQ_120);
+        
+        assertEquals(AggregationFreq.FREQ_120, victim.getTimerFrequency());
+    }
+
+    @Test
+    public void testDefaultGaugeAggregationFrequency() {
+        assertEquals(AggregationFreq.FREQ_10, victim.getGaugeFrequency());
+    }
+
+    @Test
+    public void testSetGaugeAggregationFrequency() {
+        victim.setGaugeFrequency(AggregationFreq.FREQ_120);
+
+        assertEquals(AggregationFreq.FREQ_120, victim.getGaugeFrequency());
+    }
+    
+    @Test
+    public void testDefaultCounterAggregationFrequency() {
+        assertEquals(AggregationFreq.FREQ_10, victim.getCounterFrequency());
+    }
+
+    @Test
+    public void testSetCounterAggregationFrequency() {
+        victim.setCounterFrequency(AggregationFreq.FREQ_120);
+
+        assertEquals(AggregationFreq.FREQ_120, victim.getCounterFrequency());
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void testCopyCtor() {


### PR DESCRIPTION
This also implements misc fixes on the way default configuration values are handled and increases custom metric tests coverage.