### PR TITLE
fix(NA) - Avoid using parameterized log messages

### DIFF
--- a/src/main/java/com/statful/sender/HttpSender.java
+++ b/src/main/java/com/statful/sender/HttpSender.java
@@ -81,7 +81,7 @@ public class HttpSender extends MetricsHolder {
 
         final HttpClientRequest request = client.request(HttpMethod.PUT, options.getHttpMetricsPath(), response -> {
             if (response.statusCode() != HttpResponseStatus.CREATED.code()) {
-                LOGGER.error("Failed to send metrics {}", response.statusMessage(), toSendMetrics);
+                LOGGER.error("Failed to send metrics: " + response.statusMessage() + " - Payload: " + toSendMetrics);
                 endHandler.ifPresent(callerHandler -> callerHandler.handle(Future.failedFuture(response.statusMessage())));
             } else {
                 endHandler.ifPresent(callerHandler -> callerHandler.handle(Future.succeededFuture()));

--- a/src/main/java/com/statful/sender/MetricsHolder.java
+++ b/src/main/java/com/statful/sender/MetricsHolder.java
@@ -74,8 +74,9 @@ abstract class MetricsHolder implements Sender {
 
         this.flushOnCapacity(inserted);
 
-        if (!inserted) {
-            LOGGER.warn("metric could not be added to buffer, discarding it {} ", dataPoint.toMetricLine());
+        if (!inserted && LOGGER.isDebugEnabled()) {
+            // FIXME: This should try to discard older metrics instead
+            LOGGER.debug("Metric could not be added to buffer, discarding: " +  dataPoint.toMetricLine());
         }
         return inserted;
     }
@@ -106,7 +107,7 @@ abstract class MetricsHolder implements Sender {
 
         if (dryrun) {
             final String toSendMetrics = toBeSent.stream().map(DataPoint::toMetricLine).collect(Collectors.joining("\n"));
-            LOGGER.debug("dryrun: {}", toSendMetrics);
+            LOGGER.debug("Dryrun: " + toSendMetrics);
         } else {
             this.send(toBeSent);
         }

--- a/src/main/java/com/statful/sender/UDPSender.java
+++ b/src/main/java/com/statful/sender/UDPSender.java
@@ -68,7 +68,7 @@ public final class UDPSender extends MetricsHolder {
     private void send(final Optional<Handler<AsyncResult<Void>>> endHandler, final String toSendMetrics) {
         socket.send(toSendMetrics, options.getPort(), options.getHost(), handler -> {
             if (handler.failed()) {
-                LOGGER.error("Failed to send metrics {}", handler.cause(),  toSendMetrics);
+                LOGGER.error("Failed to send metrics: " +  handler.cause() + " - Payload: " + toSendMetrics);
                 endHandler.ifPresent(callerHandler -> callerHandler.handle(Future.failedFuture(handler.cause())));
             } else {
                 endHandler.ifPresent(callerHandler -> callerHandler.handle(Future.succeededFuture()));


### PR DESCRIPTION
This is in order to abstract the client implementation from whatever logging framework the applications where the client is integrated use. By choosing a specified parameterized messages format we were binding the client logging to a particular framework (LOG4J2/SLF4J) and when using other frameworks (JUL/LOG4J1) our logging would be broken.