### PR TITLE
fix(NA) - Prevent scientific notation values on custom metrics

### DIFF
--- a/src/main/java/com/statful/client/CustomMetric.java
+++ b/src/main/java/com/statful/client/CustomMetric.java
@@ -6,6 +6,7 @@ import com.statful.utils.Pair;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.MessageCodec;
 
+import java.text.NumberFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -17,6 +18,16 @@ import static java.util.Objects.isNull;
  * Custom Metric object to be sent on the event bus
  */
 public class CustomMetric implements DataPoint {
+
+    /**
+     * Formatter to avoid scientific notation for decimal values
+     */
+    private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance();
+
+    static {
+        NUMBER_FORMAT.setMaximumFractionDigits(Integer.MAX_VALUE);
+        NUMBER_FORMAT.setGroupingUsed(false);
+    }
 
     /**
      * Statful options to be used when building the metric line
@@ -276,7 +287,7 @@ public class CustomMetric implements DataPoint {
          * @return a reference to self
          */
         public Builder withValue(final float metricValue) {
-            this.value = String.valueOf(metricValue);
+            this.value = NUMBER_FORMAT.format(metricValue);
             return this;
         }
 
@@ -285,7 +296,7 @@ public class CustomMetric implements DataPoint {
          * @return a reference to self
          */
         public Builder withValue(final double metricValue) {
-            this.value = String.valueOf(metricValue);
+            this.value = NUMBER_FORMAT.format(metricValue);
             return this;
         }
 

--- a/src/test/java/com/statful/client/StatfulCustomMetricIntegrationTest.java
+++ b/src/test/java/com/statful/client/StatfulCustomMetricIntegrationTest.java
@@ -75,7 +75,7 @@ public class StatfulCustomMetricIntegrationTest extends IntegrationTestCase {
 
         Async async = context.async();
 
-        setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(context, async);
+        setupHttpMetricsReceiverExpectationsForCustomMetricWithDefaultValue(context, async);
 
         CustomMetric metric = new CustomMetric.Builder()
                 .withMetricName("customMetricName")
@@ -93,7 +93,7 @@ public class StatfulCustomMetricIntegrationTest extends IntegrationTestCase {
 
         Async async = context.async();
 
-        setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(context, async);
+        setupHttpMetricsReceiverExpectationsForCustomMetricWithDefaultValue(context, async);
 
         CustomMetric metric = new CustomMetric.Builder()
                 .withMetricName("customMetricName")
@@ -111,11 +111,47 @@ public class StatfulCustomMetricIntegrationTest extends IntegrationTestCase {
 
         Async async = context.async();
 
-        setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(context, async);
+        setupHttpMetricsReceiverExpectationsForCustomMetricWithDefaultValue(context, async);
 
         CustomMetric metric = new CustomMetric.Builder()
                 .withMetricName("customMetricName")
                 .withValue(12345D)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithLargeDoubleValue(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+
+        setupVertxTestContext(options);
+
+        Async async = context.async();
+
+        setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(context, async, "1234567891011");
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withValue(1234567891011D)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithSmallDoubleValue(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+
+        setupVertxTestContext(options);
+
+        Async async = context.async();
+
+        setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(context, async, "0.0000000001");
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withValue(0.0000000001D)
                 .build();
 
         this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
@@ -129,11 +165,47 @@ public class StatfulCustomMetricIntegrationTest extends IntegrationTestCase {
 
         Async async = context.async();
 
-        setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(context, async);
+        setupHttpMetricsReceiverExpectationsForCustomMetricWithDefaultValue(context, async);
 
         CustomMetric metric = new CustomMetric.Builder()
                 .withMetricName("customMetricName")
                 .withValue(12345F)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithLargeFloatValue(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+
+        setupVertxTestContext(options);
+
+        Async async = context.async();
+
+        setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(context, async, "123456792");
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withValue(123456792F)
+                .build();
+
+        this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
+    }
+
+    @Test
+    public void testCustomMetricWithSmallFloatValue(TestContext context) throws Exception {
+        StatfulMetricsOptions options = getCommonStatfulMetricsOptions();
+
+        setupVertxTestContext(options);
+
+        Async async = context.async();
+
+        setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(context, async, "0.0000000001");
+
+        CustomMetric metric = new CustomMetric.Builder()
+                .withMetricName("customMetricName")
+                .withValue(0.0000000001F)
                 .build();
 
         this.vertx.eventBus().send(CustomMetricsConsumer.ADDRESS, metric);
@@ -147,7 +219,7 @@ public class StatfulCustomMetricIntegrationTest extends IntegrationTestCase {
 
         Async async = context.async();
 
-        setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(context, async);
+        setupHttpMetricsReceiverExpectationsForCustomMetricWithDefaultValue(context, async);
 
         CustomMetric metric = new CustomMetric.Builder()
                 .withMetricName("customMetricName")
@@ -514,11 +586,15 @@ public class StatfulCustomMetricIntegrationTest extends IntegrationTestCase {
         this.setUpHttpReceiver(vertx);
     }
 
-    private void setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(TestContext context, Async async) {
+    private void setupHttpMetricsReceiverExpectationsForCustomMetricWithDefaultValue(TestContext context, Async async) {
+        this.setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(context, async, "12345");
+    }
+
+    private void setupHttpMetricsReceiverExpectationsForCustomMetricWithValue(TestContext context, Async async, String expectedValue) {
         this.httpMetricsReceiver.requestHandler(packet -> packet.bodyHandler(body -> {
             String metric = body.toString();
             context.assertTrue(metric.contains("customMetricName"));
-            context.assertTrue(metric.contains("12345"));
+            context.assertTrue(metric.contains(expectedValue));
             teardown(async, context, null);
         })).listen(HTTP_SENDER_PORT, HOST, event -> {
             if (event.failed()) {


### PR DESCRIPTION
Statful does not support scientific notation for metric values